### PR TITLE
Use test-publish istead of localnet (#37) (#61)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -129,8 +129,8 @@ jobs:
       - uses: ./.github/actions/setup-sui
       - name: Run Move tests (${{ matrix.package }})
         run: |
-          sui move test --path ./packages/dapp/move/oracle-market --environment localnet --coverage --trace --test
-          sui move coverage summary --path ./packages/dapp/move/oracle-market --environment localnet --test
+          sui move test --path ./packages/dapp/move/oracle-market --environment test-publish --coverage --trace --test
+          sui move coverage summary --path ./packages/dapp/move/oracle-market --environment test-publish --test
 
   security-audit:
     if: github.event_name != 'pull_request'

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -33,7 +33,7 @@ To keep localnet-only Move.lock data out of commits, enable the repo hooks (this
 git config --local core.hooksPath .githooks
 ```
 
-This enables a pre-commit hook that strips the `[env.localnet]` block from any staged `Move.lock`.
+This enables a pre-commit hook that strips the `[env.test-publish]` block from any staged `Move.lock`.
 Your working tree may still contain the localnet block; only the commit content is cleaned.
 
 To verify hooks are enabled:

--- a/docs/04-localnet-publish.md
+++ b/docs/04-localnet-publish.md
@@ -37,7 +37,7 @@ pnpm script move:publish --package-path oracle-market
   an init witness. This is a publish-time side effect, not a runtime admin check, and it demonstrates
   how publish-time data can be anchored to the package.
   Code: `packages/dapp/move/oracle-market/sources/shop.move` (`init`, `package::claim_and_keep`)
-- **Localnet dep replacements**: the Move.toml `dep-replacements.localnet` swaps Pyth to the mock
+- **Localnet dep replacements**: the Move.toml `dep-replacements.test-publish` swaps Pyth to the mock
   package so localnet runs without real oracles.
   Code: `packages/dapp/move/oracle-market/Move.toml`
 - **Localnet regenesis**: localnet state (and object IDs) are tied to its config dir and CLI
@@ -48,7 +48,7 @@ pnpm script move:publish --package-path oracle-market
 1. `packages/dapp/src/scripts/chain/localnet-start.ts` (localnet lifecycle)
 2. `packages/dapp/src/scripts/mock/setup.ts` (mock Pyth + coins)
 3. `packages/dapp/src/scripts/move/publish.ts` (publish and artifacts)
-4. `packages/dapp/move/oracle-market/Move.toml` (dep-replacements.localnet)
+4. `packages/dapp/move/oracle-market/Move.toml` (dep-replacements.test-publish)
 
 **Code spotlight: localnet lifecycle guardrails**
 `packages/dapp/src/scripts/chain/localnet-start.ts`

--- a/docs/05-localnet-workflow.md
+++ b/docs/05-localnet-workflow.md
@@ -57,7 +57,7 @@ pnpm install
 
 Move environments (localnet/devnet/testnet/mainnet):
 - All Move packages include `[environments]` so `--environment <name>` resolves chain IDs consistently.
-- For localnet, we use `dep-replacements.localnet` to swap Pyth to the mock package without dev-mode flags.
+- For localnet, we use `dep-replacements.test-publish` to swap Pyth to the mock package without dev-mode flags.
 - Chain IDs should match `sui client chain-identifier` for each CLI env. If you regenesis localnet, update its entry:
   ```bash
   sui client switch --env localnet

--- a/packages/dapp/move/README.md
+++ b/packages/dapp/move/README.md
@@ -189,7 +189,7 @@ Reference
 Oracle Dependencies
 -------------------
 - `packages/dapp/move/oracle-market` depends on upstream Pyth + Wormhole via git in `Move.toml`.
-- `localnet` swaps Pyth to `pyth-mock` via `dep-replacements`.
+- `test-publish` swaps Pyth to `pyth-mock` via `dep-replacements`.
 
 Update instructions
 -------------------
@@ -200,6 +200,6 @@ When updating Pyth/Wormhole revisions, do the following in order.
 
 2) Re-pin the lockfile
 - From `packages/dapp/move/oracle-market`, run:
-    - `sui move build -e localnet`
-    - `sui move build -e testnet` (only if you still target testnet)
+    - `sui move build -e testnet`
+    - `sui move build -e test-publish`
     This should update/validate `Move.lock` resolution per-environment.

--- a/packages/dapp/move/coin-mock/Move.toml
+++ b/packages/dapp/move/coin-mock/Move.toml
@@ -3,4 +3,4 @@ name = "mock_coin"
 edition = "2024"
 
 [environments]
-localnet = "43bd0c5c"
+test-publish = "52911988"

--- a/packages/dapp/move/item-examples/Move.toml
+++ b/packages/dapp/move/item-examples/Move.toml
@@ -3,4 +3,4 @@ name = "item_examples"
 edition = "2024"
 
 [environments]
-localnet = "43bd0c5c"
+test-publish = "52911988"

--- a/packages/dapp/move/oracle-market/Move.toml
+++ b/packages/dapp/move/oracle-market/Move.toml
@@ -16,8 +16,8 @@ rev = "sui/testnet"
 addr_substitutions = { wormhole = "0xf47329f4344f3bf0f8e436e2f7b485466cff300f12a166563995d3888c296a94" }
 
 [environments]
-localnet = "43bd0c5c"
+test-publish = "52911988"
 testnet_beta = "4c78adac"
 
-[dep-replacements.localnet]
+[dep-replacements.test-publish]
 pyth = { local = "../pyth-mock", override = true, addr_substitutions = { pyth = "0x2" } }

--- a/packages/dapp/move/pyth-mock/Move.toml
+++ b/packages/dapp/move/pyth-mock/Move.toml
@@ -3,4 +3,4 @@ name = "pyth"
 edition = "2024"
 
 [environments]
-localnet = "43bd0c5c"
+test-publish = "52911988"

--- a/packages/tooling/node/src/move-toml.ts
+++ b/packages/tooling/node/src/move-toml.ts
@@ -4,6 +4,7 @@ import path from "node:path"
 import { formatErrorMessage } from "@sui-oracle-market/tooling-core/utils/errors"
 import type { ToolingContext } from "./factory.ts"
 import { logWarning } from "./log.ts"
+import { resolveMoveCliEnvironmentName } from "./move.ts"
 import { getSuiCliEnvironmentChainId } from "./suiCli.ts"
 import { isErrnoWithCode } from "./utils/fs.ts"
 import { escapeRegExp } from "./utils/regex.ts"
@@ -309,9 +310,13 @@ export const syncLocalnetMoveEnvironmentChainId = async (
 
   if (!chainId) return { updatedFiles: [], chainId, didAttempt: true }
 
+  const resolvedEnvironmentName = resolveMoveCliEnvironmentName(environmentName)
+  if (!resolvedEnvironmentName)
+    return { updatedFiles: [], chainId, didAttempt: true }
+
   const { updatedFiles } = await syncMoveEnvironmentChainId({
     moveRootPath,
-    environmentName,
+    environmentName: resolvedEnvironmentName,
     chainId,
     dryRun
   })

--- a/packages/tooling/node/src/process.ts
+++ b/packages/tooling/node/src/process.ts
@@ -5,12 +5,11 @@ import { createHash } from "node:crypto"
 import { basename } from "node:path"
 import { fileURLToPath } from "node:url"
 
+import { formatErrorMessage } from "@sui-oracle-market/tooling-core/utils/errors"
 import { type Argv } from "yargs"
 import { hideBin } from "yargs/helpers"
-import { formatErrorMessage } from "@sui-oracle-market/tooling-core/utils/errors"
 import type { SuiResolvedConfig } from "./config.ts"
 import { getNetworkConfig, loadSuiConfig } from "./config.ts"
-import { createSuiClient } from "./sui-client.ts"
 import type { Tooling } from "./factory.ts"
 import { createTooling } from "./factory.ts"
 import {
@@ -20,6 +19,7 @@ import {
   logSimpleBlue,
   logWarning
 } from "./log.ts"
+import { createSuiClient } from "./sui-client.ts"
 import {
   createSuiCliEnvironment,
   ensureSuiCli,
@@ -282,7 +282,7 @@ const syncLocalnetMoveEnvironmentChainIdForTooling = async (
 
   if (updatedFiles.length) {
     logKeyValueBlue("Move.toml")(
-      `updated ${updatedFiles.length} localnet environment entries`
+      `updated ${updatedFiles.length} test-publish environment entries`
     )
   }
 }

--- a/packages/tooling/node/src/publish.ts
+++ b/packages/tooling/node/src/publish.ts
@@ -114,7 +114,7 @@ const syncLocalnetMoveEnvironmentChainIdForPublish = async (
 
   if (updatedFiles.length) {
     logKeyValueBlue("Move.toml")(
-      `updated ${updatedFiles.length} localnet environment entries`
+      `updated ${updatedFiles.length} test-publish environment entries`
     )
   }
 }

--- a/packages/tooling/node/test-unit/unit/move-build.test.ts
+++ b/packages/tooling/node/test-unit/unit/move-build.test.ts
@@ -1,11 +1,11 @@
 import path from "node:path"
 import { beforeEach, describe, expect, it, vi } from "vitest"
-import { createSuiClientMock } from "../../../tests-integration/helpers/sui.ts"
 import {
   readTextFile,
   withTempDir,
   writeFileTree
 } from "../../../tests-integration/helpers/fs.ts"
+import { createSuiClientMock } from "../../../tests-integration/helpers/sui.ts"
 
 const runSuiCliMock = vi.hoisted(() => vi.fn())
 const getSuiCliEnvironmentChainIdMock = vi.hoisted(() => vi.fn())
@@ -20,12 +20,12 @@ vi.mock("../../src/log.ts", () => ({
   logWarning: logWarningMock
 }))
 
+import type { SuiResolvedConfig } from "../../src/config.ts"
 import {
   buildMovePackage,
   resolveChainIdentifier,
   syncLocalnetMoveEnvironmentChainId
 } from "../../src/move.ts"
-import type { SuiResolvedConfig } from "../../src/config.ts"
 
 const buildSuiConfig = (networkName: string): SuiResolvedConfig => ({
   currentNetwork: networkName,
@@ -116,7 +116,7 @@ describe("syncLocalnetMoveEnvironmentChainId", () => {
     })
 
     await withTempDir(async (dir) => {
-      const moveToml = `[package]\nname = "fixture"\nversion = "0.0.1"\n\n[dep-replacements.localnet]\nSui = { local = "../sui" }\n`
+      const moveToml = `[package]\nname = "fixture"\nversion = "0.0.1"\n\n[dep-replacements.test-publish]\nSui = { local = "../sui" }\n`
       await writeFileTree(dir, { "Move.toml": moveToml })
 
       const result = await syncLocalnetMoveEnvironmentChainId(
@@ -132,7 +132,7 @@ describe("syncLocalnetMoveEnvironmentChainId", () => {
 
       const updated = await readTextFile(path.join(dir, "Move.toml"))
       expect(updated).toContain("[environments]")
-      expect(updated).toContain('localnet = "0xabc"')
+      expect(updated).toContain('test-publish = "0xabc"')
     })
   })
 })

--- a/packages/tooling/node/test-unit/unit/move.test.ts
+++ b/packages/tooling/node/test-unit/unit/move.test.ts
@@ -1,22 +1,22 @@
+import type { PublishArtifact } from "@sui-oracle-market/tooling-core/types"
 import path from "node:path"
 import { describe, expect, it } from "vitest"
-import {
-  buildMoveEnvironmentFlags,
-  buildMoveTestArguments,
-  buildMoveTestPublishArguments,
-  clearPublishedEntryForNetwork,
-  resolveFullPackagePath,
-  canonicalizePackagePath,
-  hasDeploymentForPackage,
-  syncMoveEnvironmentChainId
-} from "../../src/move.ts"
-import type { PublishArtifact } from "@sui-oracle-market/tooling-core/types"
 import {
   readFixture,
   readTextFile,
   withTempDir,
   writeFileTree
 } from "../../../tests-integration/helpers/fs.ts"
+import {
+  buildMoveEnvironmentFlags,
+  buildMoveTestArguments,
+  buildMoveTestPublishArguments,
+  canonicalizePackagePath,
+  clearPublishedEntryForNetwork,
+  hasDeploymentForPackage,
+  resolveFullPackagePath,
+  syncMoveEnvironmentChainId
+} from "../../src/move.ts"
 
 describe("move helpers", () => {
   const buildPublishArtifact = (
@@ -38,7 +38,7 @@ describe("move helpers", () => {
     expect(buildMoveEnvironmentFlags({})).toEqual([])
     expect(buildMoveEnvironmentFlags({ environmentName: "localnet" })).toEqual([
       "--environment",
-      "localnet"
+      "test-publish"
     ])
   })
 
@@ -60,7 +60,7 @@ describe("move helpers", () => {
     expect(args).toEqual([
       "/tmp/pkg",
       "--build-env",
-      "localnet",
+      "test-publish",
       "--pubfile-path",
       "/tmp/publish.json",
       "--with-unpublished-dependencies"
@@ -99,7 +99,7 @@ describe("syncMoveEnvironmentChainId", () => {
 
       const result = await syncMoveEnvironmentChainId({
         moveRootPath: dir,
-        environmentName: "localnet",
+        environmentName: "test-publish",
         chainId: "0xabc"
       })
 
@@ -107,7 +107,7 @@ describe("syncMoveEnvironmentChainId", () => {
 
       const updated = await readTextFile(path.join(dir, "Move.toml"))
       expect(updated).toContain("[environments]")
-      expect(updated).toContain('localnet = "0xabc"')
+      expect(updated).toContain('test-publish = "0xabc"')
     })
   })
 
@@ -119,7 +119,7 @@ describe("syncMoveEnvironmentChainId", () => {
 
       const result = await syncMoveEnvironmentChainId({
         moveRootPath: dir,
-        environmentName: "localnet",
+        environmentName: "test-publish",
         chainId: "0x123"
       })
 

--- a/packages/tooling/tests-integration/fixtures/localnet-move/simple-contract/Move.toml
+++ b/packages/tooling/tests-integration/fixtures/localnet-move/simple-contract/Move.toml
@@ -3,4 +3,4 @@ name = "simple_contract"
 edition = "2024"
 
 [environments]
-localnet = "58157b31"
+test-publish = "58157b31"

--- a/packages/tooling/tests-integration/fixtures/move/Move.toml
+++ b/packages/tooling/tests-integration/fixtures/move/Move.toml
@@ -5,7 +5,7 @@ version = "0.0.1"
 [dependencies]
 Sui = { local = "../sui" }
 
-[dep-replacements.localnet]
+[dep-replacements.test-publish]
 Sui = { local = "../sui" }
 
 [addresses]

--- a/scripts/strip-move-localnet.js
+++ b/scripts/strip-move-localnet.js
@@ -8,7 +8,7 @@ const isStaged = args.has("--staged")
 const isAll = args.has("--all")
 const restoreAfterStage = isStaged && !args.has("--no-restore")
 
-const LOCALNET_SECTION = /\n?\[env\.localnet\][\s\S]*?(?=\n\[|$)/
+const LOCALNET_SECTION = /\n?\[env\.test-publish\][\s\S]*?(?=\n\[|$)/
 
 const getRepoRoot = () => {
   try {
@@ -157,6 +157,6 @@ const main = async () => {
 }
 
 main().catch((error) => {
-  console.error("Failed to strip [env.localnet] from Move.lock:", error)
+  console.error("Failed to strip [env.test-publish] from Move.lock:", error)
   process.exit(1)
 })


### PR DESCRIPTION
using test-publish instead of localnet in Move.toml (add utility in tooling to replace localnet by test-publish when running command against localnet)

Resolves #18